### PR TITLE
Refactor BazelRunner

### DIFF
--- a/examples/simple-no-errors/WORKSPACE
+++ b/examples/simple-no-errors/WORKSPACE
@@ -45,12 +45,20 @@ rules_proto_toolchains()
 
 register_toolchains("//toolchains:my_scala_toolchain")
 
+# optional: setup ScalaTest toolchain and dependencies
+load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
+
+scalatest_repositories()
+
+scalatest_toolchain()
+
 # Load bsp4bazel-rules
 
 local_repository(
     name = "bsp4bazel-rules",
-    path = "../../bazel_rules"
+    path = "../../bazel_rules",
 )
 
 load("@bsp4bazel-rules//:bsp4bazel_setup.bzl", "bsp4bazel_setup")
+
 bsp4bazel_setup()

--- a/examples/simple-no-errors/src/test/BUILD.bazel
+++ b/examples/simple-no-errors/src/test/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
+
+scala_test(
+    name = "all_tests",
+    srcs = glob(["*Test.scala"]),
+)

--- a/examples/simple-no-errors/src/test/example/MainTest.scala
+++ b/examples/simple-no-errors/src/test/example/MainTest.scala
@@ -1,0 +1,18 @@
+package example
+
+import collection.mutable.Stack
+import org.scalatest._
+import flatspec._
+import matchers._
+
+class ExampleSpec extends AnyFlatSpec with should.Matchers {
+
+  "A Stack" should "pop values in last-in-first-out order" in {
+    val stack = new Stack[Int]
+    stack.push(1)
+    stack.push(2)
+    stack.pop() should be(2)
+    stack.pop() should be(1)
+  }
+
+}

--- a/src/main/scala/bazeltools/bsp4bazel/Verifier.scala
+++ b/src/main/scala/bazeltools/bsp4bazel/Verifier.scala
@@ -7,7 +7,7 @@ import cats.syntax.all.*
 import fs2.io.file.Files
 import fs2.io.file.Path
 import bazeltools.bsp4bazel.runner.BazelRunner
-import bazeltools.bsp4bazel.runner.BazelRunner.BazelWrapper
+import bazeltools.bsp4bazel.runner.BspBazelRunner
 import cats.data.EitherT
 
 import bazeltools.bsp4bazel.Logger
@@ -16,11 +16,9 @@ object Verifier:
 
   lazy val Cwd = Path("")
 
-  lazy val runner: IO[BazelRunner] =
-    for wrapper <- BazelWrapper.default(Cwd.toNioPath)
-    yield BazelRunner.default(
+  lazy val runner: BspBazelRunner =
+    BspBazelRunner.default(
       Cwd.toNioPath.toAbsolutePath,
-      wrapper,
       Logger.noOp
     )
 
@@ -36,8 +34,6 @@ object Verifier:
 
     val et =
       for
-        wrapper <- BazelWrapper.default(Cwd.toNioPath).attemptT
-        runner <- runner.attemptT
         targets <- runner.bspTargets.attemptT
         result <- EitherT.cond(!targets.isEmpty, (), new Exception(msg))
       yield result

--- a/src/main/scala/bazeltools/bsp4bazel/runner/BazelRunner.scala
+++ b/src/main/scala/bazeltools/bsp4bazel/runner/BazelRunner.scala
@@ -6,6 +6,7 @@ import bazeltools.bsp4bazel.protocol.BspServer
 import bazeltools.bsp4bazel.protocol.BuildTargetIdentifier
 import bazeltools.bsp4bazel.protocol.TextDocumentIdentifier
 import bazeltools.bsp4bazel.protocol.UriFactory
+import bazeltools.bsp4bazel.runner.BazelRunner.Command
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import cats.syntax.all._
@@ -31,8 +32,10 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Success.apply
 import scala.util.Try
-import bazeltools.bsp4bazel.runner.BazelRunner.Command
 
+/** Generic Bazel runner (independent of Bsp or any particular being assumed
+  * rules)
+  */
 trait BazelRunner:
   def query(target: String): IO[BazelResult]
   def build(target: BazelLabel): IO[BazelResult]

--- a/src/main/scala/bazeltools/bsp4bazel/runner/BspBazelRunner.scala
+++ b/src/main/scala/bazeltools/bsp4bazel/runner/BspBazelRunner.scala
@@ -1,0 +1,130 @@
+package bazeltools.bsp4bazel.runner
+
+import bazeltools.bsp4bazel.FilesIO
+import bazeltools.bsp4bazel.Logger
+import bazeltools.bsp4bazel.protocol.BspServer
+import bazeltools.bsp4bazel.protocol.BuildTargetIdentifier
+import bazeltools.bsp4bazel.protocol.TextDocumentIdentifier
+import bazeltools.bsp4bazel.protocol.UriFactory
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import cats.syntax.all._
+import fs2.Stream
+import io.bazel.rules_scala.diagnostics.diagnostics.Diagnostic
+import io.bazel.rules_scala.diagnostics.diagnostics.FileDiagnostics
+import io.bazel.rules_scala.diagnostics.diagnostics.TargetDiagnostics
+import io.circe.Decoder
+import io.circe.generic.semiauto.*
+import io.circe.syntax._
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.FileSystems
+import java.nio.file.FileVisitOption
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Success.apply
+import scala.util.Try
+
+object BspBazelRunner:
+
+  def default(
+      workspaceRoot: Path,
+      logger: Logger,
+      wrapper: BazelRunner.BazelWrapper
+  ): BspBazelRunner =
+    BspBazelRunner(
+      workspaceRoot,
+      BazelRunner.default(
+        workspaceRoot,
+        logger,
+        wrapper
+      )
+    )
+
+  def default(
+      workspaceRoot: Path,
+      logger: Logger
+  ): BspBazelRunner =
+    BspBazelRunner(
+      workspaceRoot,
+      BazelRunner.default(
+        workspaceRoot,
+        logger
+      )
+    )
+
+case class BspBazelRunner(workspaceRoot: Path, runner: BazelRunner):
+
+  def bspTargets: IO[List[BspServer.Target]] =
+    for result <- runner.query("kind(bsp_target, //...)")
+    yield result.stdout
+      .map(BazelLabel.fromString)
+      .collect { case Right(label) =>
+        BspServer.Target(
+          UriFactory.bazelUri(label.asString),
+          label.target.map(_.asString).getOrElse(label.asString)
+        )
+      }
+
+  private def readSourceFile(target: BazelLabel): IO[List[String]] =
+    val filePath = workspaceRoot
+      .resolve("bazel-bin")
+      .resolve(target.packagePath.asPath)
+      .resolve("sources.json")
+    FilesIO.readJson[BazelSources](filePath).map(_.sources)
+
+  def targetSources(target: BazelLabel): IO[List[String]] =
+    runner.build(target) *>
+      readSourceFile(target)
+
+  private def diagnostics: Stream[IO, FileDiagnostics] =
+    FilesIO
+      .walk(
+        workspaceRoot.resolve("bazel-bin"),
+        Some("*.diagnosticsproto"),
+        100
+      )
+      .flatMap { file =>
+        Stream
+          .eval {
+            FilesIO.readBytes(file).map(TargetDiagnostics.parseFrom)
+          }
+          .flatMap { td =>
+            Stream.fromIterator(
+              td.diagnostics.iterator,
+              100
+            )
+          }
+      }
+
+  def compile(label: BazelLabel): Stream[IO, FileDiagnostics] =
+    Stream
+      .eval(runner.build(label.allRulesResursive))
+      .flatMap { result =>
+        result.exitCode match
+          case BazelResult.ExitCode.Ok          => Stream.empty
+          case BazelResult.ExitCode.BuildFailed => diagnostics
+          case _ =>
+            Stream.raiseError(
+              new Error(
+                s"Bsp Compile task failed: ${result.debugString}"
+              )
+            )
+      }
+
+  case class BazelSources(sources: List[String], buildFiles: List[String])
+
+  object BazelSources:
+    given Decoder[BazelSources] = Decoder.instance { c =>
+      for
+        sources <- c.downField("sources").as[List[String]]
+        buildFiles <- c.downField("buildFiles").as[List[String]]
+      yield BazelSources(sources, buildFiles)
+    }

--- a/src/main/scala/bazeltools/bsp4bazel/runner/BspBazelRunner.scala
+++ b/src/main/scala/bazeltools/bsp4bazel/runner/BspBazelRunner.scala
@@ -32,6 +32,9 @@ import scala.util.Success
 import scala.util.Success.apply
 import scala.util.Try
 
+/** Wrapper around BazelRunner for handling `./bazel_rules` rules. Specifically,
+  * it handles listing bsp_targets, reading their config, and compiling them
+  */
 object BspBazelRunner:
 
   def default(

--- a/src/test/scala/bazeltools/bsp4bazel/End2EndTest.scala
+++ b/src/test/scala/bazeltools/bsp4bazel/End2EndTest.scala
@@ -37,7 +37,6 @@ class End2EndTest extends munit.CatsEffectSuite with BspHelpers:
     setup = { test =>
       val br = BazelRunner.default(
         workspaceRoot,
-        BazelRunner.BazelWrapper.default(workspaceRoot).unsafeRunSync(),
         Logger.noOp
       )
       (br.shutdown >> br.clean).unsafeRunSync()

--- a/src/test/scala/bazeltools/bsp4bazel/runner/BazelRunnerTest.scala
+++ b/src/test/scala/bazeltools/bsp4bazel/runner/BazelRunnerTest.scala
@@ -1,0 +1,115 @@
+package bazeltools.bsp4bazel.runner
+
+import bazeltools.bsp4bazel.jrpc.Notification
+import bazeltools.bsp4bazel.protocol.BuildServerCapabilities
+import bazeltools.bsp4bazel.protocol.BuildTargetIdentifier
+import bazeltools.bsp4bazel.protocol.CompileProvider
+import bazeltools.bsp4bazel.protocol.Diagnostic
+import bazeltools.bsp4bazel.protocol.InitializeBuildResult
+import bazeltools.bsp4bazel.protocol.Position
+import bazeltools.bsp4bazel.protocol.PublishDiagnosticsParams
+import bazeltools.bsp4bazel.protocol.Range
+import bazeltools.bsp4bazel.protocol.StatusCode
+import bazeltools.bsp4bazel.protocol.TaskFinishParams
+import bazeltools.bsp4bazel.protocol.TaskStartParams
+import bazeltools.bsp4bazel.runner.BazelRunner
+import bazeltools.bsp4bazel.runner.BazelLabel
+import io.circe.Decoder
+import io.circe.Json
+import io.circe.syntax.*
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import scala.concurrent.duration._
+
+import bazeltools.bsp4bazel.BspHelpers
+import bazeltools.bsp4bazel.Lsp
+
+import bazeltools.bsp4bazel.Logger
+import bazeltools.bsp4bazel.runner.BPath.BNil
+
+class BazelRunnerTest extends munit.CatsEffectSuite:
+
+  // Long, because Github actions can run slooooow at times
+  override val munitTimeout = 10.minute
+
+  val projectRoot = Paths.get("").toAbsolutePath
+
+  def bazelEnv(workspaceRoot: Path) = FunFixture[(Path, BazelRunner)](
+    setup = { test =>
+      val br = BazelRunner.default(
+        workspaceRoot,
+        Logger.noOp
+      )
+      (br.shutdown >> br.clean).unsafeRunSync()
+      (workspaceRoot, br)
+    },
+    teardown = { (_, br) => br.shutdown }
+  )
+
+  bazelEnv(projectRoot.resolve("examples/simple-no-errors"))
+    .test("should call build in Bazel") { (root, runner) =>
+
+      val result = runner
+        .build(
+          BazelLabel(
+            None,
+            BPath.Wildcard,
+            Some(BazelTarget.AllRules)
+          )
+        )
+        .unsafeRunSync()
+
+      assertEquals(result.exitCode, BazelResult.ExitCode.Ok)
+    }
+
+  bazelEnv(projectRoot.resolve("examples/simple-no-errors"))
+    .test("should call query in Bazel") { (root, runner) =>
+
+      val result = runner
+        .query("//src/example/...")
+        .unsafeRunSync()
+
+      assertEquals(result.exitCode, BazelResult.ExitCode.Ok)
+      assertEquals(
+        result.stdout,
+        List(
+          "//src/example:example",
+          "//src/example/foo:foo",
+          "//src/example/foo:foo_bsp"
+        )
+      )
+    }
+
+  bazelEnv(projectRoot.resolve("examples/simple-no-errors"))
+    .test("should call test Bazel") { (root, runner) =>
+
+      val result = runner
+        .test(
+          BazelLabel(
+            None,
+            "src" :: "test" :: BNil,
+            Some(BazelTarget.Single("all_tests"))
+          )
+        )
+        .unsafeRunSync()
+
+      assertEquals(result.exitCode, BazelResult.ExitCode.Ok)
+      assert(result.stdout.mkString("").contains("PASSED"))
+    }
+
+  bazelEnv(projectRoot.resolve("examples/simple-no-errors"))
+    .test("should call run Bazel") { (root, runner) =>
+      val result = runner
+        .run(
+          BazelLabel(
+            None,
+            "src" :: BNil,
+            Some(BazelTarget.Single("main_run"))
+          )
+        )
+        .unsafeRunSync()
+
+      assertEquals(result.exitCode, BazelResult.ExitCode.Ok)
+      assert(result.stdout.mkString("").contains("Hello World"))
+    }


### PR DESCRIPTION
Refactoring `BazelRunner` to split out generic "Bazel running" from more BSP specific task specific running. It splits it into two classes: `BazelRunner` and `BspBazelRunner`